### PR TITLE
added "children" to interface StatusProps

### DIFF
--- a/src/QuickSearchInput.tsx
+++ b/src/QuickSearchInput.tsx
@@ -40,6 +40,7 @@ const HighlightComponent: FC = ({ children }) => (
 
 export interface StatusProps {
   hasMatch: boolean;
+  children: any;
   label?: string;
 }
 


### PR DESCRIPTION
... to get access to it when implementing a custom `StatusComponent` in typescript (to show the input/query)